### PR TITLE
Add support for java 1.6 & earlier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SublimeLinter 3 must be installed in order to use this plugin. If SublimeLinter 
 ### Linter installation
 Before using this plugin, you must ensure that `javac` is installed on your system. `javac` is part of the `java` developer SDK, which can be downloaded [here](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
 
-**NOTE:** This plugin currently supports only JDK 1.7+.
+**NOTE:** This plugin has only been tested with JDK 1.6+ , but it probably works fine with earlier versions.
 
 ### Linter configuration
 In order for `javac` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. Before going any further, please read and follow the steps in [“Finding a linter executable”](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#finding-a-linter-executable) through “Validating your PATH” in the documentation.

--- a/linter.py
+++ b/linter.py
@@ -19,12 +19,9 @@ class Javac(Linter):
 
     syntax = 'java'
     executable = 'javac'
-    version_args = '-version'
-    version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 1.7'
     regex = (
         r'^(?P<file>.+?):(?P<line>\d+): '
-        r'(?:(?P<error>error)|(?P<warning>warning)): '
+        r'((?:(?P<error>error)|(?P<warning>warning)): )?'
         r'(?:\[.+?\] )?(?P<message>[^\r\n]+)\r?\n'
         r'[^\r\n]+\r?\n'
         r'(?P<col>[^\^]*)\^'


### PR DESCRIPTION
The only difference that I could find between the javac output in 1.7 vs
1.6 is that java 1.6 doesn't include `error:` or `warning:` on the
first line, ie:

```
.../Test.java:14: ';' expected
```

instead of:

```
.../Test.java:14: error: ';' expected
```

Tested with java version 1.6.0_65 on Mac OS 10.9.2 specifically, but I
googled errors for Java 5 & Java 4 and they appear to have the same
format.
