### PR TITLE
Readme.md: Explain how to configure javac options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,34 @@ To change the settings in the same way for a single file, you would put this com
 // [SublimeLinter javac-lint:all,-deprecation]
 ```
 
+### Passing options to `javac`
+
+In order to configure `javac` options like the class path, source path, or file encoding,
+the `args` setting can be used.
+
+|Setting|Description|
+|:------|:----------|
+|`args`|An array of strings, alternating between an option and the corresponding value.|
+
+A full list of available options is given [here][1].
+
+For example, the following configuration defines the source file encoding,
+includes the two libraries `lib/some_lib.jar` and `lib/some_other_lib.jar`
+in the classpath,
+and defines `src/` as the project's source path:
+
+```
+"args": [
+    "-encoding", "UTF8",
+    "-cp", "${project}/lib/some_lib.jar:${project}/lib/some_other_lib.jar",
+    "-sourcepath", "${project}/src/"
+]
+```
+
+Note that options and their values must be separate elements in the array
+(i.e. `"args": ["-sourcepath", "/path/to/src"]` does work, while
+`"args": ["-sourcepath /path/to/src"]` does not work).
+
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 
@@ -72,3 +100,5 @@ Please note that modications should follow these coding guidelines:
 - Please use descriptive variable names, no abbrevations unless they are very well known.
 
 Thank you for helping out!
+
+[1]:http://docs.oracle.com/javase/7/docs/technotes/tools/windows/javac.html

--- a/README.md
+++ b/README.md
@@ -83,6 +83,41 @@ Note that options and their values must be separate elements in the array
 (i.e. `"args": ["-sourcepath", "/path/to/src"]` does work, while
 `"args": ["-sourcepath /path/to/src"]` does not work).
 
+See the [general SublimeLinter documentation on Settings][2] for how to
+incorporate this setting into your SublimeLinter configuration.
+
+#### Project-specific options
+
+Settings like the class path often only apply to one specific project.
+The general SublimeLinter documentation also [explains][3] how to specify
+project-specific settings in the `sublime-project` file.
+
+For the example above, such a project file could look like this:
+```
+{
+    "folders":
+    [
+        {
+            "path": "."
+        }
+    ],
+    "SublimeLinter":
+    {
+        "linters":
+        {
+            "javac": {
+                "lint": "all",
+                "args": [
+                    "-encoding", "UTF8",
+                     "-cp", "${project}/lib/some_lib.jar:${project}/lib/some_other_lib.jar",
+                    "-sourcepath", "${project}/src/"
+                ]
+            }
+        }
+    }
+}
+```
+
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 
@@ -102,3 +137,5 @@ Please note that modications should follow these coding guidelines:
 Thank you for helping out!
 
 [1]:http://docs.oracle.com/javase/7/docs/technotes/tools/windows/javac.html
+[2]:http://sublimelinter.readthedocs.org/en/latest/settings.html#settings
+[3]:http://sublimelinter.readthedocs.org/en/latest/settings.html#project-settings


### PR DESCRIPTION
For many users (myself included), it is not obvious how to configure
the classpath that the linter should use, and guidance for how to
do this is spread across open and closed issues.

This adds a short explanation to the Readme that shows how to pass
arguments to `javac`, and points out the pitfall that options
and their values need to be stored in separate array elements.

I'd be happy to hear what you guys think, and if you find this useful.