### PR TITLE
Allow separate classpath configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,29 @@ Note that options and their values must be separate elements in the array
 (i.e. `"args": ["-sourcepath", "/path/to/src"]` does work, while
 `"args": ["-sourcepath /path/to/src"]` does not work).
 
+#### Classpath
+
+|Setting|Description|
+|:------|:----------|
+|`classpath`|Elements for the classpath. Accepts a list.|
+
+To configure classpaths with a lot of elements, the `classpath` setting may
+be used alternatively or in addition to `args`.
+
+If *`-sourcepath` is unspecified* (in `args`), `-classpath` can also be used to configure source paths.
+
+The above example would look like this:
+
+```
+"args": ["-encoding", "UTF8"],
+"classpath": [
+    "${folder}/lib/some_lib.jar",
+    "${folder}/lib/some_other_lib.jar",
+    "${folder}/src/", // sourcepath elements go here, too
+]
+```
+
+
 #### Project-specific options
 
 Settings like the class path often only apply to one specific project.
@@ -87,10 +110,11 @@ For the example above, such a project file could look like this:
     "settings":
     {
         "SublimeLinter.linters.javac.lint": "all",
-        "SublimeLinter.linters.javac.args": [
-            "-encoding", "UTF8",
-             "-cp", "${folder}/lib/some_lib.jar:${folder}/lib/some_other_lib.jar",
-            "-sourcepath", "${folder}/src/"
+        "SublimeLinter.linters.javac.args": ["-encoding", "UTF8"],
+        "SublimeLinter.linters.javac.classpath": [
+            "${folder}/lib/some_lib.jar",
+            "${folder}/lib/some_other_lib.jar",
+            "${folder}/src/",
         ]
     }
 }

--- a/linter.py
+++ b/linter.py
@@ -14,6 +14,7 @@ class Javac(Linter):
     error_stream = util.STREAM_STDERR
     defaults = {
         'lint': '',
+        '-classpath::': [],
         'selector': 'source.java'
     }
 


### PR DESCRIPTION
This adds `classpath` as an additional configuration option to configure  *javac.*

Per the discussion on SublimeLinter/SublimeLinter-clang#10 it became clear that it is preferred to *not* add extra configuration option beyond `args`. However, specifying a long list of paths for *javac* is tedious, as elements are colon-separated and thus cannot be individual elements in an `args` list.

This is completely optional, and offers better maintainability for users working on big projects.
Additionally, it allows to set general flags in the preferences of SublimeLinter, while still offering the possibility of setting custom paths for every project.

It is enough to offer `classpath`. When `-sourcepath` or `-processorpath` are not specified, the classpath will be searched for source files and annotation processors, too.

* * *

A comparison for [Litho][]:

```
// classpath
"classpath": [
  "${project_path}/litho-intellij-plugin/src/main/java",
  "${project_path}/litho-sections-widget/src/main/java",
  "${project_path}/litho-processor/src/main/java",
  "${project_path}/litho-rendercore/src/main/java",
  "${project_path}/litho-testing/src/main/java",
  "${project_path}/litho-instrumentation-tests/src/main/java",
  "${project_path}/litho-core/src/main/java",
  "${project_path}/codelabs/props/app/src/main/java",
  "${project_path}/codelabs/layout-spec/app/src/main/java",
  "${project_path}/codelabs/hello-world/app/src/main/java",
  "${project_path}/codelabs/hscroll-height/app/src/main/java",
  "${project_path}/codelabs/state/app/src/main/java",
  "${project_path}/codelabs/updating-ui/app/src/main/java",
  "${project_path}/codelabs/save-state-rotation/app/src/main/java",
  "${project_path}/codelabs/textinput-keyboard/app/src/main/java",
  "${project_path}/codelabs/mount-spec/app/src/main/java",
  "${project_path}/codelabs/events/app/src/main/java",
  "${project_path}/codelabs/group-section-lifecycle/app/src/main/java",
  "${project_path}/litho-sections-core/src/main/java",
  "${project_path}/sample-codelab/src/main/java",
  "${project_path}/litho-sections-debug/src/main/java",
  "${project_path}/litho-annotations/src/main/java",
  "${project_path}/sample-barebones/src/main/java",
  "${project_path}/litho-widget/src/main/java",
  "${project_path}/litho-it/specs/src/main/java",
  "${project_path}/litho-it/processor/src/main/java",
  "${project_path}/litho-it/src/main/java",
  "${project_path}/sample-barebones-kotlin/src/main/java",
  "${project_path}/sample/src/main/java",
  "${project_path}/lib/yoga/src/main/java",
  "${project_path}/litho-espresso/src/main/java",
  "${project_path}/litho-sections-annotations/src/main/java",
  "${project_path}/litho-fresco/src/main/java",
  "${project_path}/litho-sections-processor/src/main/java",
]

// args
"args": [
  "-sourcepath",
  "${project_path}/litho-intellij-plugin/src/main/java:${project_path}/litho-sections-widget/src/main/java:${project_path}/litho-processor/src/main/java:${project_path}/litho-rendercore/src/main/java:${project_path}/litho-testing/src/main/java:${project_path}/litho-instrumentation-tests/src/main/java:${project_path}/litho-core/src/main/java:${project_path}/codelabs/props/app/src/main/java:${project_path}/codelabs/layout-spec/app/src/main/java:${project_path}/codelabs/hello-world/app/src/main/java:${project_path}/codelabs/hscroll-height/app/src/main/java:${project_path}/codelabs/state/app/src/main/java:${project_path}/codelabs/updating-ui/app/src/main/java:${project_path}/codelabs/save-state-rotation/app/src/main/java:${project_path}/codelabs/textinput-keyboard/app/src/main/java:${project_path}/codelabs/mount-spec/app/src/main/java:${project_path}/codelabs/events/app/src/main/java:${project_path}/codelabs/group-section-lifecycle/app/src/main/java:${project_path}/litho-sections-core/src/main/java:${project_path}/sample-codelab/src/main/java:${project_path}/litho-sections-debug/src/main/java:${project_path}/litho-annotations/src/main/java:${project_path}/sample-barebones/src/main/java:${project_path}/litho-widget/src/main/java:${project_path}/litho-it/specs/src/main/java:${project_path}/litho-it/processor/src/main/java:${project_path}/litho-it/src/main/java:${project_path}/sample-barebones-kotlin/src/main/java:${project_path}/sample/src/main/java:${project_path}/lib/yoga/src/main/java:${project_path}/litho-espresso/src/main/java:${project_path}/litho-sections-annotations/src/main/java:${project_path}/litho-fresco/src/main/java:${project_path}/litho-sections-processor/src/main/java",
]
```

[Litho]: https://github.com/facebook/litho/